### PR TITLE
fix: standardize secret name from PAT_TOKEN to GH_TOKEN across workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/init-request.md
+++ b/.github/ISSUE_TEMPLATE/init-request.md
@@ -10,7 +10,7 @@ To initialize your fork management repository, I need to know which repository y
    - `admin:read:org` (Read organization information)
    - `admin:write:repo_hook` (Full control of repository hooks)
    - `write:discussion` (Add comments to issues and pull requests)
-2. Add the token as a repository secret named `PAT_TOKEN`
+2. Add the token as a repository secret named `GH_TOKEN`
 3. Comment on this issue with the upstream repository to sync with, using either:
    - GitHub format: `owner/repo`
    - GitLab URL: `https://gitlab.com/owner/repo`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: "Generate Release PR"
         uses: google-github-actions/release-please-action@v4
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
           release-type: simple
           package-name: repo-sync
           changelog-types: |
@@ -86,7 +86,7 @@ jobs:
           
       - name: "Update Release Tags"
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           # Get the latest release tag
           RELEASE_TAG=$(gh release list -L 1 | cut -f 3)

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Install Trivy
         run: |
@@ -55,7 +55,7 @@ jobs:
 
       - name: Create required labels
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           # Create labels if they don't exist
           gh label create sync-failed \
@@ -72,7 +72,7 @@ jobs:
 
       - name: Create sync branch and PR
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           AZURE_API_KEY: ${{ secrets.AZURE_API_KEY }}
           AZURE_API_BASE: ${{ secrets.AZURE_API_BASE }}
@@ -191,7 +191,7 @@ jobs:
       - name: Create issue on failure
         if: failure()
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           ISSUE_BODY="The automated upstream sync workflow failed.
 


### PR DESCRIPTION
## Summary
- Standardized all workflow files to use `GH_TOKEN` instead of `PAT_TOKEN`
- Fixed inconsistency between documentation and implementation
- Resolves sync workflow failures for users following setup instructions

## Changes
- Updated `sync.yml`: 4 occurrences of PAT_TOKEN → GH_TOKEN
- Updated `release.yml`: 2 occurrences of PAT_TOKEN → GH_TOKEN  
- Updated `init-request.md`: Updated setup instructions to reference GH_TOKEN

## Test Plan
- [ ] Verify sync workflow runs successfully with GH_TOKEN secret
- [ ] Verify release workflow can access GH_TOKEN for release creation
- [ ] Confirm init process documentation matches implementation

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)