### PR TITLE
fix: remove MCP file copying and implement manual configuration workflow

### DIFF
--- a/.github/fork-resources/mcp-config.json
+++ b/.github/fork-resources/mcp-config.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "mvn-mcp-server": {
-      "type": "stdio",
+      "type": "local",
       "command": "uvx",
       "args": [
         "--from",
@@ -9,7 +9,9 @@
         "mvn-mcp-server"
       ],
       "env": {},
-      "tools": ["*"]
+      "tools": [
+        "*"
+      ]
     }
   }
 }

--- a/.github/sync-config.json
+++ b/.github/sync-config.json
@@ -150,10 +150,6 @@
         "reason": "Template-specific Claude instructions"
       },
       {
-        "path": ".github/copilot-instructions.md",
-        "reason": "Template-specific AI instructions"
-      },
-      {
         "path": ".github/ISSUE_TEMPLATE/branch-protection-reminder.md",
         "reason": "Template initialization issue template"
       },

--- a/.github/workflows/init-complete.yml
+++ b/.github/workflows/init-complete.yml
@@ -440,12 +440,6 @@ jobs:
             git add ".github/copilot-instructions.md"
           fi
           
-          # Copy MCP server configuration for GitHub Copilot Agent
-          if [ -f ".github/fork-resources/mcp-config.json" ]; then
-            echo "Installing MCP server configuration for GitHub Copilot Agent..."
-            cp ".github/fork-resources/mcp-config.json" ".github/mcp-config.json"
-            git add ".github/mcp-config.json"
-          fi
           
           # Copy GitHub Copilot firewall configuration
           if [ -f ".github/fork-resources/copilot-firewall-config.json" ]; then
@@ -650,7 +644,9 @@ jobs:
 
           ✅ **Automated Workflows:** Sync, validation, and release workflows are active
 
-          ✅ **AI Enhancement:** GitHub Copilot Agent configured with Maven MCP Server and firewall allowlist for OSDU domains
+          ✅ **AI Enhancement:** GitHub Copilot Agent firewall allowlist configured for OSDU domains
+          
+          ⚠️ **MCP Configuration:** Maven MCP Server requires manual setup (see new issue created above)
 
           ✅ **Template Cleanup:** Removed template documentation (upstream README will be used)
 
@@ -669,6 +665,81 @@ jobs:
 
           **Happy coding!** 🚀
           EOF
+
+      - name: Create MCP Configuration Issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Create issue for manual MCP configuration
+          cat << 'EOF' > mcp-setup.md
+          # 🤖 Configure MCP Server for GitHub Copilot Agent
+          
+          To enable the Maven MCP Server for GitHub Copilot Agent in this repository, you need to manually configure it in the repository settings.
+          
+          ## Configuration Steps
+          
+          1. **Navigate to Repository Settings**:
+             - Go to your repository on GitHub.com
+             - Click on **Settings** (you must be a repository admin)
+             - In the left sidebar under "Code & automation", click **Copilot** → **Copilot agent**
+          
+          2. **Add MCP Configuration**:
+             - Scroll to the **MCP configuration** section
+             - Replace the existing JSON with:
+          
+          ```json
+          {
+            "mcpServers": {
+              "mvn-mcp-server": {
+                "type": "local",
+                "command": "uvx",
+                "args": [
+                  "--from",
+                  "git+https://github.com/danielscholl-osdu/mvn-mcp-server@main",
+                  "mvn-mcp-server"
+                ],
+                "env": {},
+                "tools": [
+                  "*"
+                ]
+              }
+            }
+          }
+          ```
+          
+          3. **Save Configuration**:
+             - The configuration will be validated when you save
+             - If validation passes, the MCP server will be available to GitHub Copilot Agent
+          
+          ## What This Enables
+          
+          The Maven MCP Server provides GitHub Copilot Agent with capabilities to:
+          - Analyze Maven project structures
+          - Understand dependencies and build configurations
+          - Provide context-aware assistance for Java/Maven projects
+          - Help with build issues and dependency management
+          
+          ## Verification
+          
+          After configuration, you can verify the setup by:
+          1. Assigning an issue to `@copilot` 
+          2. The agent should have enhanced Maven project understanding
+          
+          ## Manual Configuration Required
+          
+          ⚠️ **Important**: This configuration cannot be automated via API. Repository administrators must configure it manually in the GitHub UI.
+          
+          ---
+          
+          Close this issue after completing the MCP configuration.
+          EOF
+          
+          gh issue create \
+            --title "🤖 Configure MCP Server for GitHub Copilot Agent" \
+            --body-file mcp-setup.md \
+            --label "configuration,copilot"
+            
+          echo "Created MCP configuration issue"
 
       - name: Complete Initialization
         env:

--- a/doc/mcp-integration.md
+++ b/doc/mcp-integration.md
@@ -35,7 +35,7 @@ Navigate to your fork repository settings:
 {
   "mcpServers": {
     "mvn-mcp-server": {
-      "type": "stdio",
+      "type": "local",
       "command": "uvx",
       "args": [
         "--from",
@@ -70,7 +70,7 @@ If your Maven projects require specific environment variables:
 {
   "mcpServers": {
     "mvn-mcp-server": {
-      "type": "stdio",
+      "type": "local",
       "command": "uvx",
       "args": [
         "--from",
@@ -195,12 +195,12 @@ The MCP server integrates with existing fork workflows:
 
 ## Template Integration
 
-This MCP configuration is automatically applied to new fork repositories when using the initialization workflow. See [Initialization Workflow](init-workflow.md) for details on automated setup.
+**Manual Configuration Required**: MCP configuration cannot be automated via GitHub APIs and must be configured manually in each fork repository's settings. The initialization workflow creates an issue with detailed setup instructions.
 
 ### Related Workflows
-- **init.yml**: Applies MCP configuration during repository setup
-- **sync.yml**: Enhanced with dependency analysis capabilities
-- **build.yml**: Can leverage security scanning for build decisions
+- **init-complete.yml**: Creates an issue with MCP configuration instructions after repository setup
+- **sync.yml**: Enhanced with dependency analysis capabilities when MCP is configured
+- **build.yml**: Can leverage security scanning for build decisions when MCP is configured
 
 ## Future Enhancements
 


### PR DESCRIPTION
## Summary

- Removes automatic MCP configuration file copying from initialization workflow
- Adds manual MCP configuration issue creation with detailed setup instructions  
- Updates MCP configuration format from 'stdio' to 'local' type
- Fixes copilot-instructions.md cleanup conflict in sync-config.json

## Background

GitHub Copilot Agent MCP configuration must be done manually in repository settings. There is currently no API support for automating this configuration, so the previous approach of copying a file was incorrect and misleading.

## Changes Made

### Workflow Updates
- **Removed**: MCP file copying from `init-complete.yml` 
- **Added**: Issue creation step with detailed manual setup instructions
- **Updated**: Status message to clarify MCP setup is manual

### Configuration Updates  
- **Fixed**: MCP config type from `"stdio"` to `"local"` for GitHub Copilot Agent
- **Removed**: Conflicting cleanup rule for `copilot-instructions.md` in sync-config.json

### Documentation Updates
- **Updated**: `doc/mcp-integration.md` to reflect manual configuration requirement
- **Clarified**: Template integration section to note API limitations

## Test Plan

- [ ] Verify initialization workflow creates MCP configuration issue with correct instructions
- [ ] Confirm copilot-instructions.md is preserved during initialization (no longer cleaned up)
- [ ] Validate MCP JSON configuration syntax is correct
- [ ] Test that manual MCP setup works in repository settings

## Related Issue

Closes #38

🤖 Generated with [Claude Code](https://claude.ai/code)