### PR TITLE
fix(init): resolve label error and add prompt file copying in init-complete workflow

### DIFF
--- a/.github/workflows/init-complete.yml
+++ b/.github/workflows/init-complete.yml
@@ -448,6 +448,14 @@ jobs:
             git add ".github/copilot-firewall-config.json"
           fi
           
+          # Copy triage prompt file to prompts directory
+          if [ -f ".github/fork-resources/triage.prompt.md" ]; then
+            echo "Installing triage prompt for dependency analysis..."
+            mkdir -p "prompts"
+            cp ".github/fork-resources/triage.prompt.md" "prompts/triage.prompt.md"
+            git add "prompts/triage.prompt.md"
+          fi
+          
           # Clean up fork-resources directory after copying
           if [ -d ".github/fork-resources" ]; then
             echo "Removing fork-resources directory after copying..."
@@ -737,7 +745,7 @@ jobs:
           gh issue create \
             --title "🤖 Configure MCP Server for GitHub Copilot Agent" \
             --body-file mcp-setup.md \
-            --label "configuration,copilot"
+            --label "high-priority,copilot"
             
           echo "Created MCP configuration issue"
 


### PR DESCRIPTION
## Summary

Fixes two critical bugs in the init-complete workflow that were causing initialization failures:

• Fixed invalid label reference error when creating MCP configuration issues
• Added missing logic to copy triage prompt files to fork instances

## Changes

### Bug 1: Label Error Fix
- **Problem**: Workflow failed with `could not add label: 'configuration' not found`
- **Solution**: Replace non-existent 'configuration' label with 'high-priority' label
- **Location**: `.github/workflows/init-complete.yml:740`

### Bug 2: Missing Prompt File Copy
- **Problem**: `triage.prompt.md` from `.github/fork-resources/` was not being copied during initialization
- **Solution**: Added logic to copy prompt file to `prompts/` directory before cleanup
- **Location**: Added new section in fork-resources copying logic

## Test Plan

- [x] Verified 'high-priority' label exists in labels.json
- [x] Added proper error handling for missing files
- [x] Ensured prompts directory creation and git staging
- [ ] Test initialization workflow with these changes

## Linked Issues

Fixes #42

🤖 Generated with [Claude Code](https://claude.ai/code)