### PR TITLE
fix(init): correct prompts directory location and add .vscode copying

### DIFF
--- a/.github/workflows/init-complete.yml
+++ b/.github/workflows/init-complete.yml
@@ -448,12 +448,21 @@ jobs:
             git add ".github/copilot-firewall-config.json"
           fi
           
-          # Copy triage prompt file to prompts directory
+          # Copy triage prompt file to .github/prompts directory
           if [ -f ".github/fork-resources/triage.prompt.md" ]; then
             echo "Installing triage prompt for dependency analysis..."
-            mkdir -p "prompts"
-            cp ".github/fork-resources/triage.prompt.md" "prompts/triage.prompt.md"
-            git add "prompts/triage.prompt.md"
+            mkdir -p ".github/prompts"
+            cp ".github/fork-resources/triage.prompt.md" ".github/prompts/triage.prompt.md"
+            git add ".github/prompts/triage.prompt.md"
+          fi
+          
+          # Copy .vscode configuration directory
+          if [ -d ".github/fork-resources/.vscode" ]; then
+            echo "Installing .vscode MCP configuration..."
+            mkdir -p ".vscode"
+            cp -r ".github/fork-resources/.vscode/"* ".vscode/"
+            # Force add .vscode files even if gitignore might affect them
+            git add -f ".vscode/"
           fi
           
           # Clean up fork-resources directory after copying


### PR DESCRIPTION
## Summary
- Fix prompts directory creation from 'prompts/' to '.github/prompts/'
- Add missing .vscode directory copying from fork-resources to repository root

## Changes Made
1. **Prompts Directory Location Fix**: Changed `mkdir -p "prompts"` to `mkdir -p ".github/prompts"` and updated all related paths in init-complete.yml:451-457
2. **Added .vscode Directory Copying**: Added new logic in init-complete.yml:459-466 to copy `.github/fork-resources/.vscode/` to `.vscode/` with force add to handle gitignore conflicts

## Root Cause Analysis
- The workflow was creating prompts at repository root instead of the expected `.github/prompts/` location
- No logic existed to copy the .vscode MCP configuration from fork-resources to the repository root
- .vscode files are allowed by gitignore (`\!.vscode`) but needed force add for safety

## Test Plan
- [ ] Verify prompts are created in `.github/prompts/` during initialization
- [ ] Verify .vscode directory is copied to repository root
- [ ] Confirm MCP configuration is available for Claude Code integration

🤖 Generated with [Claude Code](https://claude.ai/code)