### PR TITLE
feat: enhance Claude workflow with tool permissions and Java/Maven setup

### DIFF
--- a/.github/template-workflows/claude.yml
+++ b/.github/template-workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
     steps:
       - name: Checkout repository
@@ -29,16 +29,47 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Set up Java and Maven
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'zulu'
+          cache: 'maven'
+
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: 3.9.6
+
+      - name: Install UV and Trivy for MCP server
+        run: |
+          # Install UV for Python MCP server
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          
+          # Install Trivy for vulnerability scanning
+          sudo apt-get update
+          sudo apt-get install wget apt-transport-https gnupg lsb-release
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
+          echo "deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update
+          sudo apt-get install trivy
+
       - name: Run Claude PR Action
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: "60"
+          allowed_tools: "Bash,Task,mcp__mvn-mcp-server__list_dependencies,mcp__mvn-mcp-server__check_updates,mcp__mvn-mcp-server__analyze_vulnerabilities,mcp__mvn-mcp-server__get_dependency_tree,mcp__mvn-mcp-server__run_maven_command"
           mcp_config: |
             {
               "mcpServers": {
                 "mvn-mcp-server": {
-                  "type": "stdio",
                   "command": "uvx",
                   "args": [
                     "--from",


### PR DESCRIPTION
## Summary

Enhances the Claude Code GitHub Action workflow template to fix tool access issues and improve Maven/Java support for dependency triage operations.

### Key Improvements

- **🔧 Fixed Tool Permissions**: Added `allowed_tools` configuration to enable Bash and MCP server tools
- **🔒 Enhanced Permissions**: Upgraded GitHub permissions from read-only to write access  
- **☕ Java Environment**: Added Java 11 (Zulu OpenJDK) with Maven 3.9.6 and caching
- **🐍 Python Setup**: Added Python 3.11 and UV installation for MCP server
- **🛡️ Security Tools**: Installed Trivy vulnerability scanner for mvn-mcp-server
- **⚡ Performance**: Added Maven dependency caching for faster builds

### Problem Solved

Previously, Claude Code actions failed with:
- `Claude requested permissions to use Bash, but you haven't granted it yet`
- MCP server status: `"failed"` due to missing dependencies
- Limited to read-only operations, unable to commit changes

### Testing Required

- [ ] Verify Bash tool access works in workflow runs
- [ ] Confirm mvn-mcp-server connects successfully  
- [ ] Test dependency triage operations complete without errors
- [ ] Validate Maven commands execute properly in Spring Boot projects

This change is backward compatible and improves the template for all fork management instances.

🤖 Generated with [Claude Code](https://claude.ai/code)