### PR TITLE
fix: add missing MCP configuration to resolve mvn-mcp-server connection failures

### DIFF
--- a/.github/fork-resources/mcp-config.json
+++ b/.github/fork-resources/mcp-config.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "mvn-mcp-server": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/danielscholl-osdu/mvn-mcp-server@main",
+        "mvn-mcp-server"
+      ],
+      "env": {},
+      "tools": ["*"]
+    }
+  }
+}

--- a/.github/workflows/init-complete.yml
+++ b/.github/workflows/init-complete.yml
@@ -481,6 +481,13 @@ jobs:
             git add ".github/workflows/copilot-setup-steps.yml"
           fi
           
+          # Copy MCP configuration
+          if [ -f ".github/fork-resources/mcp-config.json" ]; then
+            echo "Installing MCP configuration for GitHub Copilot Agent..."
+            cp ".github/fork-resources/mcp-config.json" ".github/mcp-config.json"
+            git add ".github/mcp-config.json"
+          fi
+          
           # Clean up fork-resources directory after copying
           if [ -d ".github/fork-resources" ]; then
             echo "Removing fork-resources directory after copying..."


### PR DESCRIPTION
## Summary
- Add missing `mcp-config.json` to fork-resources for automatic deployment
- Update init-complete.yml workflow to copy MCP configuration during initialization  
- Resolves GitHub Copilot Agent connection failures to mvn-mcp-server in fork repositories

## Test plan
- [x] Verify mcp-config.json file exists in fork-resources
- [x] Confirm init-complete.yml copies MCP configuration
- [ ] Test with new fork repository initialization

🤖 Generated with [Claude Code](https://claude.ai/code)