### PR TITLE
fix: remove inline comments from cascade.yml multiline conditional

### DIFF
--- a/.github/template-workflows/cascade.yml
+++ b/.github/template-workflows/cascade.yml
@@ -25,12 +25,12 @@ jobs:
   cascade-to-integration:
     name: "🔄 Cascade to Integration"
     if: >
-      (github.ref == 'refs/heads/fork_upstream') ||                              # Triggered by push to fork_upstream
-      (github.event_name == 'pull_request' &&                                   # Triggered by pull request event
-       github.event.pull_request.merged == true &&                              # PR must be merged
-       github.event.pull_request.base.ref == 'fork_upstream' &&                 # Base branch is fork_upstream
-       contains(github.event.pull_request.labels.*.name, 'upstream-sync')) ||   # Label indicates upstream sync
-      (github.event_name == 'workflow_dispatch')                                # Triggered manually
+      (github.ref == 'refs/heads/fork_upstream') ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.merged == true &&
+       github.event.pull_request.base.ref == 'fork_upstream' &&
+       contains(github.event.pull_request.labels.*.name, 'upstream-sync')) ||
+      (github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Fixed YAML syntax error in `.github/template-workflows/cascade.yml`
- Removed inline comments from multiline conditional expression
- Preserved conditional logic and readability

## Problem
The cascade.yml template workflow contained YAML syntax errors due to inline comments in a multiline conditional expression on line 27-33. This caused GitHub Actions validation failures:

```
Unexpected symbol: '#'. Located at position 76 within expression: (github.ref == 'refs/heads/fork_upstream') ||                              # Triggered by push to fork_upstream
```

## Solution
Removed the inline comments while maintaining the conditional logic structure. The YAML now validates successfully with `yq`.

## Test Plan
- [x] YAML syntax validation passes (`yq e '.' cascade.yml`)
- [x] Conditional logic preserved
- [x] No functional changes to workflow behavior

## Impact
- ✅ Fixes GitHub Actions workflow validation failures
- ✅ Maintains cascade workflow functionality  
- ✅ Improves template reliability for fork instances

Fixes #68

🤖 Generated with [Claude Code](https://claude.ai/code)