### PR TITLE
fix: use repository variable instead of secret for upstream URL in release workflow

### DIFF
--- a/.github/template-workflows/release.yml
+++ b/.github/template-workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           
       - name: "Fetch Upstream Version"
         run: |
-          git remote add upstream ${{ secrets.UPSTREAM_REPO_URL }}
+          git remote add upstream ${{ vars.UPSTREAM_REPO_URL }}
           git fetch upstream --tags
           UPSTREAM_VERSION=$(git describe --tags --abbrev=0 upstream/main 2>/dev/null || echo "v0.0.0")
           echo "UPSTREAM_VERSION=$UPSTREAM_VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

Fixes the release management workflow failure where `git remote add upstream` was missing the URL parameter.

Resolves #72

## Changes

- Changed `${{ secrets.UPSTREAM_REPO_URL }}` to `${{ vars.UPSTREAM_REPO_URL }}` in `.github/template-workflows/release.yml`
- Aligns with the initialization process that sets `UPSTREAM_REPO_URL` as a repository variable, not a secret

## Root Cause

The initialization workflow in `init-complete.yml` correctly sets `UPSTREAM_REPO_URL` as a repository variable (line 191), but the release workflow was incorrectly trying to access it as a secret.

## Impact

- ✅ Fixes release workflow failures in forked repositories  
- ✅ Enables proper upstream version tracking in releases
- ✅ Maintains consistency with initialization process

## Test Plan

- [x] Template repository: Workflow syntax validation passes
- [ ] Fork repository: Test release workflow runs successfully after this fix
- [ ] Verify upstream version detection works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)