### PR TITLE
fix: add missing checkout step to cascade workflow check-stale-conflicts job

### DIFF
--- a/.github/template-workflows/cascade.yml
+++ b/.github/template-workflows/cascade.yml
@@ -246,6 +246,9 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
       - name: Check for stale conflict PRs
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary

- Fixes missing `actions/checkout@v4` step in the `check-stale-conflicts` job
- Resolves GitHub CLI failure when checking for stale conflict PRs
- Ensures SLA monitoring feature works correctly in cascade workflow

## Problem

The cascade workflow was failing when the `check-stale-conflicts` job ran with the error:
```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

## Root Cause

The `check-stale-conflicts` job was missing the repository checkout step that provides the necessary git context for GitHub CLI commands.

## Solution

Added `actions/checkout@v4` step to the `check-stale-conflicts` job in `.github/template-workflows/cascade.yml`.

## Test Plan

- [x] Manual testing showed the workflow now has proper repository context
- [ ] Verify the cascade workflow runs successfully with stale conflict detection

Fixes #74

🤖 Generated with [Claude Code](https://claude.ai/code)