### PR TITLE
fix: correct MCP Server issue label to use existing human-required label

### DIFF
--- a/.github/workflows/init-complete.yml
+++ b/.github/workflows/init-complete.yml
@@ -770,7 +770,7 @@ jobs:
           gh issue create \
             --title "🤖 Configure MCP Server for GitHub Copilot Agent" \
             --body-file mcp-setup.md \
-            --label "human-needed"
+            --label "human-required"
             
           echo "Created MCP configuration issue"
 


### PR DESCRIPTION
## Summary

- Fixes critical workflow failure that prevented initialization issue auto-close
- Updates MCP Server issue label from `human-needed` to `human-required` 
- Resolves label mismatch that caused `gh issue create` to fail in init workflow

## Root Cause Analysis

The previous PR #79 changed the label to `human-needed`, but this label doesn't exist in `.github/labels.json`. The correct label name is `human-required`.

When `gh issue create` fails due to a non-existent label, it stops the entire `init-complete.yml` workflow before reaching the final step that auto-closes the "Repository Initialization Required" issue.

## Changes Made

- Changed `.github/workflows/init-complete.yml` line 773 from `human-needed` to `human-required`
- Verified label exists in `.github/labels.json` (line 129-132)

## Impact

- ✅ Fixes workflow completion and initialization issue auto-close
- ✅ Ensures MCP Server issue is properly labeled for human action
- ✅ Maintains the intent of requiring human intervention for MCP setup

## Test Plan

- [x] Verified `human-required` label exists in labels.json
- [ ] Test full initialization workflow with corrected label
- [ ] Confirm initialization issue auto-closes after MCP issue creation

Fixes #80

🤖 Generated with [Claude Code](https://claude.ai/code)