### PR TITLE
fix: populate issue number in sync workflow cascade instructions

### DIFF
--- a/.github/template-workflows/sync.yml
+++ b/.github/template-workflows/sync.yml
@@ -253,7 +253,16 @@ jobs:
           # Get commit count for the notification
           COMMIT_COUNT=$(git rev-list --count fork_upstream..${{ env.SYNC_BRANCH }})
           
-          # Build notification body using printf to avoid YAML issues  
+          # Create issue first to get the issue number
+          ISSUE_URL=$(gh issue create \
+            --title "📥 Upstream Sync Ready for Review - $(date +%Y-%m-%d)" \
+            --body "Creating sync tracking issue..." \
+            --label "upstream-sync,human-required")
+          
+          # Extract issue number
+          ISSUE_NUMBER=$(basename "$ISSUE_URL")
+          
+          # Build notification body with the actual issue number
           printf -v NOTIFICATION_BODY '%s\n\n%s\n\n%s\n\n%s\n\n%s\n%s\n%s\n%s\n\n%s\n\n%s\n%s\n%s\n%s\n\n%s\n\n%s\n\n%s\n\n%s\n%s\n\n%s\n\n%s\n%s\n\n%s\n\n%s\n%s\n%s\n\n%s\n\n%s\n\n%s\n%s\n%s\n%s\n\n%s\n\n%s\n\n%s\n\n%s\n%s\n%s' \
             "📥 **Upstream Sync Ready for Review**" \
             "This issue tracks the integration of upstream changes into your fork." \
@@ -296,13 +305,8 @@ jobs:
             "- **Sync detected**: \`$(date -u +%Y-%m-%dT%H:%M:%SZ)\`" \
             "- **Current status**: Awaiting PR review and merge"
           
-          ISSUE_URL=$(gh issue create \
-            --title "📥 Upstream Sync Ready for Review - $(date +%Y-%m-%d)" \
-            --body "$NOTIFICATION_BODY" \
-            --label "upstream-sync,human-required")
-          
-          # Extract issue number for next step outputs
-          ISSUE_NUMBER=$(basename "$ISSUE_URL")
+          # Update the issue with the complete description
+          gh issue edit "$ISSUE_NUMBER" --body "$NOTIFICATION_BODY"
 
       - name: Log sync completion
         if: steps.sync-changes.outputs.has_changes == 'true'


### PR DESCRIPTION
## Summary

Fixes a bug in the sync workflow where the issue number was not being populated in the cascade instructions, showing an empty field instead of the actual issue number users need to enter.

## Problem

When the sync workflow creates a tracking issue, the cascade instructions contained:
```
- In the issue_number field, enter: ``
```

Instead of the actual issue number.

## Root Cause

The workflow was trying to use `$ISSUE_NUMBER` in the printf statement before the issue was actually created, so the variable was undefined.

## Solution

Restructured the issue creation process:
1. Create issue first with placeholder body
2. Extract issue number immediately  
3. Build complete description with actual issue number
4. Update issue with complete description

## Testing

- [x] Workflow syntax is valid
- [ ] Manual test: Run sync workflow and verify issue description shows correct issue number
- [ ] Integration test: Full sync → cascade workflow flow

## Impact

- ✅ Users see correct issue number in cascade instructions
- ✅ Improves workflow usability and reduces confusion  
- ✅ No breaking changes to workflow behavior

Closes #93

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>