### PR TITLE
feat: Skip conventional commit validation for GitHub Copilot PRs

### DIFF
--- a/.github/template-workflows/validate.yml
+++ b/.github/template-workflows/validate.yml
@@ -202,6 +202,9 @@ jobs:
         if: |
           needs.check-repo-state.outputs.is_initialized == 'true' && 
           github.actor != 'dependabot[bot]' &&
+          github.actor != 'copilot' &&
+          !contains(github.actor, 'copilot') &&
+          !contains(github.event.pull_request.user.login, 'copilot') &&
           github.base_ref == 'main' &&
           !contains(github.head_ref, 'fork_') &&
           !startsWith(github.event.pull_request.title, 'chore(sync)') &&


### PR DESCRIPTION
## Summary
- Modify validation workflow to skip conventional commit validation for GitHub Copilot-created PRs
- Allows 'Initial plan' commits to pass validation while maintaining strict validation for human-created PRs

## Problem
GitHub Copilot creates PRs with "Initial plan" commits that don't follow conventional commit format (missing colon). This causes validation failures for legitimate AI-generated PRs.

## Solution
Updated `.github/template-workflows/validate.yml` to detect GitHub Copilot PRs and skip conventional commit validation:

- Skip validation when `github.actor` is 'copilot' or contains 'copilot'
- Skip validation when PR author contains 'copilot'
- Supports various Copilot agent username variations (copilot, Copilot, copilot-swe-agent, etc.)

## Testing
- ✅ Human-created PRs continue to have strict conventional commit validation
- ✅ GitHub Copilot PRs skip validation and can include "Initial plan" commits
- ✅ Existing exemptions (dependabot, sync workflows) remain unchanged

## Impact
- Enables seamless GitHub Copilot integration without compromising validation for human PRs
- Maintains existing validation behavior for all other scenarios
- No breaking changes to current workflow

🤖 Generated with [Claude Code](https://claude.ai/code)