### PR TITLE
fix: resolve template fetch ambiguity in sync-template workflow

### DIFF
--- a/.github/template-workflows/sync-template.yml
+++ b/.github/template-workflows/sync-template.yml
@@ -34,8 +34,8 @@ jobs:
             git remote add template "$TEMPLATE_REPO_URL"
           fi
           
-          # Fetch latest from template
-          git fetch template --prune
+          # Fetch latest from template (explicit branch ref to avoid tag ambiguity)
+          git fetch template refs/heads/main:refs/remotes/template/main --prune
 
       - name: Check for template updates
         id: check-updates
@@ -160,7 +160,7 @@ jobs:
           echo "SYNC_BRANCH=$SYNC_BRANCH" >> $GITHUB_ENV
           
           # Create and checkout sync branch from main
-          git checkout -b $SYNC_BRANCH main
+          git checkout -b $SYNC_BRANCH refs/heads/main
 
       - name: Sync template files
         if: steps.check-updates.outputs.has_updates == 'true'


### PR DESCRIPTION
## Summary
- Fix template fetch to use explicit branch reference to avoid tag/branch ambiguity
- Update checkout command to use explicit refs/heads/main  
- Prevents "ambiguous object name: 'main'" error when template repo has both main branch and main tag

## Root Cause Analysis
The sync-template workflow was failing because:
1. Template repository has both a `main` branch AND a `main` tag
2. `git fetch template --prune` fetches ALL refs (branches + tags)
3. Later references to `template/main` become ambiguous

## Changes Made
1. **Line 38**: Changed `git fetch template --prune` to `git fetch template refs/heads/main:refs/remotes/template/main --prune`
2. **Line 163**: Changed `git checkout -b $SYNC_BRANCH main` to `git checkout -b $SYNC_BRANCH refs/heads/main`

## Test Plan
- [x] YAML syntax validation passes
- [ ] Test sync-template workflow on a fork repository
- [ ] Verify no ambiguity errors occur

## Related Issues
- Fixes #127
- Supersedes PR #126 (contains unnecessary init workflow changes)
- Related to failed workflow: https://github.com/danielscholl-osdu/file/actions/runs/16230791727

🤖 Generated with [Claude Code](https://claude.ai/code)