### PR TITLE
fix: add GH_TOKEN and error handling to sync-state-manager cleanup

### DIFF
--- a/.github/actions/sync-state-manager/action.yml
+++ b/.github/actions/sync-state-manager/action.yml
@@ -125,6 +125,8 @@ runs:
     - name: "Clean up abandoned sync branches"
       id: cleanup
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
         echo "Cleaning up abandoned sync branches..."
         
@@ -150,15 +152,20 @@ runs:
               
               # Check if branch is older than threshold
               if [ "$BRANCH_TIME" -lt "$CLEANUP_THRESHOLD" ] && [ "$BRANCH_TIME" -gt "0" ]; then
-                # Check if there's an associated open PR
-                ASSOCIATED_PR=$(gh pr list --head "$branch" --state open --json number | jq -r '.[0].number // empty' 2>/dev/null || echo "")
+                # Check if there's an associated open PR with proper error handling
+                echo "   Checking for associated PR for branch: $branch"
+                ASSOCIATED_PR=$(gh pr list --head "$branch" --state open --json number 2>/dev/null | jq -r '.[0].number // empty' 2>/dev/null)
+                GH_EXIT_CODE=$?
                 
-                if [ -z "$ASSOCIATED_PR" ]; then
-                  echo "⚠️ Found abandoned branch: $branch (age: $((CURRENT_TIME - BRANCH_TIME)) seconds)"
+                if [ $GH_EXIT_CODE -ne 0 ]; then
+                  echo "   ⚠️ Warning: gh command failed for branch $branch (exit code: $GH_EXIT_CODE)"
+                  echo "   Skipping cleanup for safety - manual intervention may be required"
+                elif [ -z "$ASSOCIATED_PR" ]; then
+                  echo "   ⚠️ Found abandoned branch: $branch (age: $((CURRENT_TIME - BRANCH_TIME)) seconds)"
                   echo "   Deleting abandoned branch..."
                   git push origin --delete "$branch" 2>/dev/null || echo "   Failed to delete branch (may not exist)"
                 else
-                  echo "✅ Branch $branch has associated PR #$ASSOCIATED_PR - keeping"
+                  echo "   ✅ Branch $branch has associated PR #$ASSOCIATED_PR - keeping"
                 fi
               fi
             fi


### PR DESCRIPTION
## Problem

The sync-state-manager action has a critical bug in its cleanup logic that causes PR branches to be deleted while PRs are still open. This happens when the `gh` command fails due to missing `GH_TOKEN` environment variable.

## Root Cause Analysis

From sync workflow logs, we discovered:
1. PR created successfully on Day 1 ✅
2. Day 2 sync runs cleanup logic
3. `gh pr list` fails with: `gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable` ❌
4. Cleanup logic assumes no PR exists and deletes the branch ❌
5. Sync workflow fails when trying to update non-existent branch ❌

## Changes Made

- **Added `GH_TOKEN` environment variable** to cleanup step (lines 128-129)
- **Added proper error handling** for `gh` command failures (lines 160-162)
- **Implemented fail-safe approach** - skip cleanup when `gh` commands fail

## Impact

- **Before**: PR branches deleted while PRs are open, causing workflow failures
- **After**: Safe cleanup that only deletes truly abandoned branches

## Testing

The fix addresses the exact scenario that caused the original issue in the partition repository sync workflow.

Fixes #129