### PR TITLE
fix: add deduplication to progress comments in sync workflow

### DIFF
--- a/.github/template-workflows/sync.yml
+++ b/.github/template-workflows/sync.yml
@@ -489,8 +489,9 @@ jobs:
           
           Please review the updated changes and merge when ready."
           
-          # Clear the reminder SHA since we've updated - allows new reminders after this update
+          # Clear the reminder and progress SHAs since we've updated - allows new comments after this update
           git config --unset sync.last-reminder-sha || true
+          git config --unset sync.last-progress-sha || true
           
           # Set outputs for consistency
           echo "pr-url=${{ github.server_url }}/${{ github.repository }}/pull/$PR_NUMBER" >> $GITHUB_OUTPUT
@@ -610,6 +611,14 @@ jobs:
           PR_NUMBER="${{ steps.sync-state.outputs.existing_pr_number }}"
           UPSTREAM_VERSION="${{ env.UPSTREAM_VERSION }}"
           
+          # Check if we've already sent a progress comment for this upstream version
+          LAST_PROGRESS_SHA=$(git config --get sync.last-progress-sha || echo "")
+          
+          if [ "$LAST_PROGRESS_SHA" = "$UPSTREAM_VERSION" ]; then
+            echo "⏭️ Skipping progress comment - already sent for upstream version $UPSTREAM_VERSION"
+            exit 0
+          fi
+          
           # Add a progress comment about the update
           gh issue comment "$ISSUE_NUMBER" --body "🔄 **Sync Updated**
           
@@ -620,6 +629,9 @@ jobs:
           **Updated at**: \`$(date -u +%Y-%m-%dT%H:%M:%SZ)\`
           
           Please review the updated changes and merge when ready. The same workflow process continues."
+          
+          # Track that we sent a progress comment for this upstream version
+          git config sync.last-progress-sha "$UPSTREAM_VERSION"
           
           echo "📝 Added progress comment to existing issue #$ISSUE_NUMBER"
 


### PR DESCRIPTION
## Problem

The initial fix in #135 only addressed duplicate **reminder comments** (`🔔 Sync Reminder`), but duplicate **progress comments** (`🔄 Sync Updated`) were still occurring.

## Real-World Testing Results

After testing #135, duplicate progress comments were still observed:
- Multiple `🔄 Sync Updated` comments for the same upstream SHA (`ff084f51`)
- Issue #5 in partition repository shows duplicate progress comments
- Creates noise in issue threads and confuses reviewers

## Root Cause Analysis

The "Add progress comment to existing issue" step (triggered by `sync_decision == 'update_existing'`) **lacked deduplication logic**. 

Our previous fix only addressed the "Add reminder comment" step, leaving progress comments unprotected.

## Solution

Extend the deduplication system to cover **both** comment types:

### 1. **Dual Tracking System**
- `sync.last-reminder-sha` - Tracks reminder comments ✅ (from #135)
- `sync.last-progress-sha` - Tracks progress comments ✅ (this PR)

### 2. **Progress Comment Deduplication**
```bash
# Check if we've already sent a progress comment for this upstream version
LAST_PROGRESS_SHA=$(git config --get sync.last-progress-sha || echo "")

if [ "$LAST_PROGRESS_SHA" = "$UPSTREAM_VERSION" ]; then
  echo "⏭️ Skipping progress comment - already sent for upstream version $UPSTREAM_VERSION"
  exit 0
fi
```

### 3. **Clear Both Tracking Types on Update**
```bash
# Clear the reminder and progress SHAs since we've updated
git config --unset sync.last-reminder-sha || true
git config --unset sync.last-progress-sha || true
```

## Complete Fix Coverage

✅ **Reminder Comments** (`🔔 Sync Reminder`) - Fixed in #135
✅ **Progress Comments** (`🔄 Sync Updated`) - Fixed in this PR

## Before vs After

**Before (with #135 only):**
- No duplicate reminder comments ✅
- Still duplicate progress comments ❌

**After (with this PR):**
- No duplicate reminder comments ✅
- No duplicate progress comments ✅
- Complete deduplication coverage ✅

## Expected Behavior

- **No duplicate progress comments** for same upstream SHA
- **No duplicate reminder comments** for same upstream SHA  
- **Proper comment tracking** reset when PR actually updates
- **Clean, non-duplicative** sync workflow communication

This completes the duplicate comment fix started in #135 and provides comprehensive protection against all types of duplicate sync workflow comments.

Fixes #137