### PR TITLE
fix: update Claude workflow permissions to enable write access

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     


### PR DESCRIPTION
## Summary
Fixes Claude Code GitHub Action permission errors by updating workflow permissions from read to write.

## Changes
- Updated `.github/workflows/claude.yml` permissions:
  - `contents: read` → `contents: write`
  - `pull-requests: read` → `pull-requests: write` 
  - `issues: read` → `issues: write`

## Problem Solved
Resolves 401 Unauthorized errors that were preventing the Claude Code action from:
- Creating comments on PRs and issues
- Updating PR status
- Performing code changes

## Testing
- [ ] Claude Code action runs without permission errors
- [ ] Action can create comments on PRs and issues

Fixes #157

🤖 Generated with [Claude Code](https://claude.ai/code)