### PR TITLE
fix: pass GitLab token as input parameter to java-build action

### DIFF
--- a/.github/actions/java-build/action.yml
+++ b/.github/actions/java-build/action.yml
@@ -6,6 +6,9 @@ inputs:
     description: 'Whether to generate coverage report'
     required: false
     default: 'false'
+  gitlab_token:
+    description: 'GitLab token for Maven authentication'
+    required: false
 
 outputs:
   is_java_project:
@@ -70,7 +73,7 @@ runs:
         fi
       env:
         MAVEN_OPTS: "-Dmaven.repo.local=$HOME/.m2/repository"
-        COMMUNITY_MAVEN_TOKEN: ${{ env.GITLAB_TOKEN }}
+        COMMUNITY_MAVEN_TOKEN: ${{ inputs.gitlab_token }}
 
     - name: "Upload Build Artifacts"
       if: steps.check_pom.outputs.has_pom == 'true'

--- a/.github/template-workflows/build.yml
+++ b/.github/template-workflows/build.yml
@@ -82,8 +82,6 @@ jobs:
     needs: check-repo-state
     if: needs.check-repo-state.outputs.initialized == 'true' && needs.check-repo-state.outputs.is_java_project == 'true'
     runs-on: ubuntu-latest
-    env:
-      COMMUNITY_MAVEN_TOKEN: ${{ secrets.GITLAB_TOKEN }}
     outputs:
       is_java_project: ${{ steps.build.outputs.is_java_project }}
       build_result: ${{ steps.build.outputs.build_result }}
@@ -93,14 +91,14 @@ jobs:
       - name: "Run Java Build"
         id: build
         uses: ./.github/actions/java-build
+        with:
+          gitlab_token: ${{ secrets.GITLAB_TOKEN }}
 
   code-coverage:
     name: "📊 Code Coverage"
     needs: [check-repo-state, java-build]
     if: needs.check-repo-state.outputs.is_java_project == 'true'
     runs-on: ubuntu-latest
-    env:
-      COMMUNITY_MAVEN_TOKEN: ${{ secrets.GITLAB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -123,6 +121,7 @@ jobs:
       - name: "Generate Coverage Report"
         env:
           MAVEN_OPTS: "-Dmaven.repo.local=$HOME/.m2/repository"
+          COMMUNITY_MAVEN_TOKEN: ${{ secrets.GITLAB_TOKEN }}
         run: |
           # Set up Maven CLI options
           MAVEN_CLI_OPTS="--batch-mode -Drevision=${GITHUB_REF_NAME}-SNAPSHOT"

--- a/.github/template-workflows/dependabot-validation.yml
+++ b/.github/template-workflows/dependabot-validation.yml
@@ -80,9 +80,9 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OPENGROUP_MAVEN_USERNAME }}
           MAVEN_TOKEN: ${{ secrets.OPENGROUP_MAVEN_TOKEN }}
-          COMMUNITY_MAVEN_TOKEN: ${{ secrets.GITLAB_TOKEN }}
         with:
           generate_coverage: true
+          gitlab_token: ${{ secrets.GITLAB_TOKEN }}
       
       - name: "Post Build Status Comment"
         uses: ./.github/actions/pr-status

--- a/.github/template-workflows/validate.yml
+++ b/.github/template-workflows/validate.yml
@@ -213,9 +213,9 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OPENGROUP_MAVEN_USERNAME }}
           MAVEN_TOKEN: ${{ secrets.OPENGROUP_MAVEN_TOKEN }}
-          COMMUNITY_MAVEN_TOKEN: ${{ secrets.GITLAB_TOKEN }}
         with:
           generate_coverage: ${{ github.event_name == 'pull_request' }}
+          gitlab_token: ${{ secrets.GITLAB_TOKEN }}
 
   code-validation:
     name: "✅ Code Quality Checks"


### PR DESCRIPTION
## Summary

This PR fixes Maven authentication by passing the GitLab token as an input parameter to the composite action instead of relying on environment variables.

### Problem Fixed
Maven authentication was failing even with properly configured repository secrets because composite actions don't automatically inherit environment variables from workflows.

### Root Cause Analysis
1. **Organization secrets** aren't passed to fork PR workflows (GitHub security feature)
2. **Environment variables** weren't reaching the composite action even with repository secrets
3. **Composite actions** require secrets to be passed as input parameters rather than environment variables

### Solution Implemented
1. **Added `gitlab_token` input parameter** to java-build action
2. **Mapped `COMMUNITY_MAVEN_TOKEN`** environment variable to `inputs.gitlab_token`
3. **Updated all workflows** to pass `gitlab_token` as input parameter:
   - `build.yml`: Pass `gitlab_token` to java-build step
   - `validate.yml`: Pass `gitlab_token` to java-build step  
   - `dependabot-validation.yml`: Pass `gitlab_token` to java-build step
4. **Removed debug logging** after successful testing
5. **Cleaned up environment variable approach** that didn't work

### How It Works
- The workflow passes `gitlab_token: ${{ secrets.GITLAB_TOKEN }}` as input
- The composite action receives it as `inputs.gitlab_token`
- Maps it to `COMMUNITY_MAVEN_TOKEN` environment variable for Maven
- Maven settings detect the token and activate the private token authentication profile

### Testing Results
✅ `COMMUNITY_MAVEN_TOKEN is set: YES`
✅ Maven authentication now works with GitLab package registry
✅ Successfully resolved dependencies like `org.opengroup.osdu:os-core-common:jar:3.5.2`

### Impact
- Enables Maven authentication with GitLab package registry in all workflows
- Fixes 401 Unauthorized errors when accessing GitLab Maven packages
- Maintains compatibility with existing Maven settings configuration
- Template sync will distribute this fix to all fork instances

Fixes #174

🤖 Generated with [Claude Code](https://claude.ai/code)