### PR TITLE
fix: prevent duplicate sync comments by fixing state persistence

### DIFF
--- a/.github/actions/sync-state-manager/action.yml
+++ b/.github/actions/sync-state-manager/action.yml
@@ -50,12 +50,17 @@ runs:
     - name: "Check stored sync state"
       id: stored_state
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
-        # Get stored state from git config
-        LAST_UPSTREAM_SHA=$(git config --get sync.last-upstream-sha || echo "")
-        CURRENT_PR_NUMBER=$(git config --get sync.current-pr-number || echo "")
-        CURRENT_ISSUE_NUMBER=$(git config --get sync.current-issue-number || echo "")
-        LAST_SYNC_TIMESTAMP=$(git config --get sync.last-sync-timestamp || echo "")
+        # Get stored state from GitHub repository variables
+        echo "Fetching sync state from repository variables..."
+        
+        # Get variables with error handling
+        LAST_UPSTREAM_SHA=$(gh api "repos/$GITHUB_REPOSITORY/actions/variables/SYNC_LAST_UPSTREAM_SHA" --jq '.value' 2>/dev/null || echo "")
+        CURRENT_PR_NUMBER=$(gh api "repos/$GITHUB_REPOSITORY/actions/variables/SYNC_CURRENT_PR_NUMBER" --jq '.value' 2>/dev/null || echo "")
+        CURRENT_ISSUE_NUMBER=$(gh api "repos/$GITHUB_REPOSITORY/actions/variables/SYNC_CURRENT_ISSUE_NUMBER" --jq '.value' 2>/dev/null || echo "")
+        LAST_SYNC_TIMESTAMP=$(gh api "repos/$GITHUB_REPOSITORY/actions/variables/SYNC_LAST_TIMESTAMP" --jq '.value' 2>/dev/null || echo "")
         
         echo "last_upstream_sha=$LAST_UPSTREAM_SHA" >> $GITHUB_OUTPUT
         echo "current_pr_number=$CURRENT_PR_NUMBER" >> $GITHUB_OUTPUT
@@ -247,13 +252,35 @@ runs:
     - name: "Update sync state"
       id: update_state
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
-        # Update stored state
+        # Update stored state in GitHub repository variables
         UPSTREAM_SHA="${{ steps.upstream_sha.outputs.upstream_sha }}"
         CURRENT_TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
         
-        git config sync.last-upstream-sha "$UPSTREAM_SHA"
-        git config sync.last-sync-timestamp "$CURRENT_TIMESTAMP"
+        echo "Updating sync state in repository variables..."
+        
+        # Update upstream SHA and timestamp
+        gh api "repos/$GITHUB_REPOSITORY/actions/variables/SYNC_LAST_UPSTREAM_SHA" \
+          -X PATCH \
+          -f name="SYNC_LAST_UPSTREAM_SHA" \
+          -f value="$UPSTREAM_SHA" 2>/dev/null || \
+        gh api "repos/$GITHUB_REPOSITORY/actions/variables" \
+          -X POST \
+          -f name="SYNC_LAST_UPSTREAM_SHA" \
+          -f value="$UPSTREAM_SHA" 2>/dev/null || \
+        echo "⚠️ Warning: Could not update SYNC_LAST_UPSTREAM_SHA variable"
+        
+        gh api "repos/$GITHUB_REPOSITORY/actions/variables/SYNC_LAST_TIMESTAMP" \
+          -X PATCH \
+          -f name="SYNC_LAST_TIMESTAMP" \
+          -f value="$CURRENT_TIMESTAMP" 2>/dev/null || \
+        gh api "repos/$GITHUB_REPOSITORY/actions/variables" \
+          -X POST \
+          -f name="SYNC_LAST_TIMESTAMP" \
+          -f value="$CURRENT_TIMESTAMP" 2>/dev/null || \
+        echo "⚠️ Warning: Could not update SYNC_LAST_TIMESTAMP variable"
         
         # Update PR and issue numbers if creating new ones
         if [ "${{ steps.decision.outputs.should_create_pr }}" = "true" ]; then

--- a/.github/template-workflows/sync.yml
+++ b/.github/template-workflows/sync.yml
@@ -12,6 +12,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      actions: write  # Required to update repository variables for state persistence
 
     steps:
       - name: Checkout main (contains workflows and actions)
@@ -375,7 +376,15 @@ jobs:
           echo "PR number: $PR_NUMBER"
           
           # Update sync state with new PR number
-          git config sync.current-pr-number "$PR_NUMBER"
+          gh api "repos/$GITHUB_REPOSITORY/actions/variables/SYNC_CURRENT_PR_NUMBER" \
+            -X PATCH \
+            -f name="SYNC_CURRENT_PR_NUMBER" \
+            -f value="$PR_NUMBER" 2>/dev/null || \
+          gh api "repos/$GITHUB_REPOSITORY/actions/variables" \
+            -X POST \
+            -f name="SYNC_CURRENT_PR_NUMBER" \
+            -f value="$PR_NUMBER" 2>/dev/null || \
+          echo "⚠️ Warning: Could not update SYNC_CURRENT_PR_NUMBER variable"
           
           # Set outputs for next step
           echo "pr-url=$PR_URL" >> $GITHUB_OUTPUT
@@ -478,18 +487,24 @@ jobs:
             --title "⬆️ Sync with upstream $UPSTREAM_VERSION (Updated)" \
             --body "$PR_DESCRIPTION"
           
-          # Add comment to the PR about the update
-          gh pr comment "$PR_NUMBER" --body "🔄 **Sync Updated**
+          # Check for existing "Sync Updated" comments to prevent duplicates
+          EXISTING_COMMENT=$(gh pr view "$PR_NUMBER" --json comments --jq '.comments[] | select(.body | contains("🔄 **Sync Updated**")) | .body' | grep -c "New upstream version.*$UPSTREAM_VERSION" || echo "0")
           
-          The upstream repository has advanced since this PR was created. This branch has been updated with the latest changes from upstream.
-          
-          **New upstream version**: \`$UPSTREAM_VERSION\`
-          **Updated at**: \`$(date -u +%Y-%m-%dT%H:%M:%SZ)\`
-          **PR description**: Regenerated to include all commits (original + new changes)
-          
-          Please review the updated changes and merge when ready."
-          
-          # Note: Comment deduplication now uses existing comment checking rather than git config tracking
+          if [ "$EXISTING_COMMENT" = "0" ]; then
+            # Add comment to the PR about the update
+            gh pr comment "$PR_NUMBER" --body "🔄 **Sync Updated**
+            
+            The upstream repository has advanced since this PR was created. This branch has been updated with the latest changes from upstream.
+            
+            **New upstream version**: \`$UPSTREAM_VERSION\`
+            **Updated at**: \`$(date -u +%Y-%m-%dT%H:%M:%SZ)\`
+            **PR description**: Regenerated to include all commits (original + new changes)
+            
+            Please review the updated changes and merge when ready."
+            echo "✅ Added sync update comment for upstream version $UPSTREAM_VERSION"
+          else
+            echo "ℹ️ Skipping duplicate comment - sync update for $UPSTREAM_VERSION already exists"
+          fi
           
           # Set outputs for consistency
           echo "pr-url=${{ github.server_url }}/${{ github.repository }}/pull/$PR_NUMBER" >> $GITHUB_OUTPUT
@@ -519,7 +534,15 @@ jobs:
           ISSUE_NUMBER=$(basename "$ISSUE_URL")
           
           # Update sync state with new issue number
-          git config sync.current-issue-number "$ISSUE_NUMBER"
+          gh api "repos/$GITHUB_REPOSITORY/actions/variables/SYNC_CURRENT_ISSUE_NUMBER" \
+            -X PATCH \
+            -f name="SYNC_CURRENT_ISSUE_NUMBER" \
+            -f value="$ISSUE_NUMBER" 2>/dev/null || \
+          gh api "repos/$GITHUB_REPOSITORY/actions/variables" \
+            -X POST \
+            -f name="SYNC_CURRENT_ISSUE_NUMBER" \
+            -f value="$ISSUE_NUMBER" 2>/dev/null || \
+          echo "⚠️ Warning: Could not update SYNC_CURRENT_ISSUE_NUMBER variable"
           
           # Build notification body with the actual issue number
           printf -v NOTIFICATION_BODY '%s\n\n%s\n\n%s\n\n%s\n\n%s\n%s\n%s\n%s\n\n%s\n\n%s\n%s\n%s\n%s\n\n%s\n\n%s\n\n%s\n\n%s\n%s\n\n%s\n\n%s\n%s\n\n%s\n\n%s\n%s\n%s\n\n%s\n\n%s\n\n%s\n%s\n%s\n%s\n\n%s\n\n%s\n\n%s\n\n%s\n%s\n%s' \


### PR DESCRIPTION
## Summary

Fixes the bug where Sync Upstream workflow adds duplicate "🔄 Sync Updated" comments to PRs daily, even when upstream hasn't changed.

**Fixes #186**

## Root Cause

The `sync-state-manager` action was using `git config` to store state between workflow runs, but git config is local to GitHub Actions runners. Each run gets a fresh runner, so stored values were lost, causing the workflow to think upstream had changed every time.

## Solution

- **Replace git config with GitHub repository variables** for persistent state storage
- **Add proper state persistence** across workflow runs via `SYNC_*` variables
- **Add comment deduplication** to prevent duplicate comments for same upstream version
- **Update workflow permissions** to include `actions: write` for variables API access
- **Remove redundant git config calls** in favor of centralized API updates

## Changes

### Files Modified
- `.github/actions/sync-state-manager/action.yml` - Replace git config with GitHub API
- `.github/template-workflows/sync.yml` - Add permissions and comment deduplication

### Technical Details
- Uses GitHub repository variables: `SYNC_LAST_UPSTREAM_SHA`, `SYNC_CURRENT_PR_NUMBER`, `SYNC_CURRENT_ISSUE_NUMBER`, `SYNC_LAST_TIMESTAMP`
- Includes proper error handling with fallback to empty values
- Adds comment deduplication by checking existing PR comments before adding new ones

## Test Plan

Deploy to a fork repository and observe:
- [ ] State persists between workflow runs
- [ ] No duplicate comments when upstream hasn't changed
- [ ] Proper "reminder" behavior when PR exists but upstream unchanged
- [ ] Normal sync behavior when upstream actually advances

## Expected Behavior After Fix

| Existing PR | Upstream Changed | Action (per ADR-024) |
|-------------|------------------|----------------------|
| No | Yes | Create new PR and issue |
| Yes | No | Add reminder comment (not "Sync Updated") |
| Yes | Yes | Update existing branch + single update comment |
| No | No | No action needed |

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>